### PR TITLE
bump albumentations; support resuming of training

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,7 +25,8 @@ pip install jupyterlab --upgrade
 pip install scikit-image tqdm wget
 pip install cython pyyaml lmdb
 pip install opencv-python opencv-contrib-python
-pip install open3d albumentations requests
+pip install open3d requests
+pip install albumentations>=5.1.0
 pip install qimage2ndarray
 pip install imageio-ffmpeg
 pip install face-alignment dlib

--- a/train.py
+++ b/train.py
@@ -24,6 +24,7 @@ def parse_args():
     parser.add_argument('--seed', type=int, default=0, help='Random seed.')
     parser.add_argument('--local_rank', type=int, default=0)
     parser.add_argument('--single_gpu', action='store_true')
+    parser.add_argument('--resume', action='store_true')
     parser.add_argument('--num_workers', type=int)
     args = parser.parse_args()
     return args
@@ -61,7 +62,7 @@ def main():
                           sch_G, sch_D,
                           train_data_loader, val_data_loader)
     current_epoch, current_iteration = trainer.load_checkpoint(
-        cfg, args.checkpoint)
+        cfg, args.checkpoint,resume=args.resume)
 
     # Start training.
     for epoch in range(current_epoch, cfg.max_epoch):


### PR DESCRIPTION
This PR does two things:

1) Requires a minimum version of albumentations (fixes an issue I found with running on Colab)
2) Allows you to resume training using the `--resume` argument. The code to resume training already existed in this repo but by default was always set to `None`. Passing in `--resume` with the train.py script now sets it to `True`