### PR TITLE
Fixed container_abcs removed from torch._six

### DIFF
--- a/imaginaire/utils/misc.py
+++ b/imaginaire/utils/misc.py
@@ -9,8 +9,15 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from scipy.stats import truncnorm
-from torch._six import container_abcs, string_classes
+from torch._six import string_classes
 
+TORCH_MAJOR = int(torch.__version__.split('.')[0])
+TORCH_MINOR = int(torch.__version__.split('.')[1])
+
+if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
+    from torch._six import container_abcs
+else:
+    import collections.abc as container_abcs
 
 def split_labels(labels, label_lengths):
     r"""Split concatenated labels into their parts.


### PR DESCRIPTION
As per https://github.com/NVIDIA/apex/pull/1049

> Nightly PyTorch has removed container_abcs from torch._six.
> pytorch/pytorch@58eb233#diff-b3c160475f0fbe8ad50310f92d3534172ba98203387a962b7dc8f4a23b15cf4dL35

Change
```
from torch._six import container_abcs
```

to:
```
TORCH_MAJOR = int(torch.__version__.split('.')[0])
TORCH_MINOR = int(torch.__version__.split('.')[1])

if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
    from torch._six import container_abcs
else:
    import collections.abc as container_abcs
```