### PR TITLE
Fix Google Drive download and specify opencv version

### DIFF
--- a/imaginaire/utils/io.py
+++ b/imaginaire/utils/io.py
@@ -69,11 +69,14 @@ def download_file(URL, destination):
 
     """
     session = requests.Session()
-    response = session.get(URL, stream=True)
-    token = get_confirm_token(response)
-    if token:
-        params = {'confirm': token}
-        response = session.get(URL, params=params, stream=True)
+    if 'google' in URL:
+        response = session.post(URL + "&confirm=t")
+    else:
+        response = session.get(URL, stream=True)
+        token = get_confirm_token(response)
+        if token:
+            params = {'confirm': token}
+            response = session.get(URL, params=params, stream=True)
     save_response_content(response, destination)
 
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -8,8 +8,9 @@ wget
 cython
 lmdb
 av
-opencv-python
-opencv-contrib-python
+opencv-python==4.5.4.58
+opencv-python-headless==4.5.4.58
+opencv-contrib-python==4.5.4.58
 imutils
 imageio-ffmpeg
 qimage2ndarray


### PR DESCRIPTION
In trying to set up the repository to recreate the [World Consistent Video2Video](https://github.com/NVlabs/imaginaire/tree/master/projects/wc_vid2vid), I hit two errors that I have fixed in this PR.

The Google Drive download protocol used in `io.py` no longer works due to a change in how Google Drive handles requests. The current `io.py` will cause all downloads to silently fail because it will download a Google Drive HTML warning. The original logic appears to be similar to that of [this StackOverflow post](https://stackoverflow.com/questions/38511444/python-download-files-from-google-drive-using-url) and so I adapted the [last comment](https://stackoverflow.com/questions/38511444/python-download-files-from-google-drive-using-url#comment126879887_39225272) so that it uses a `POST` request including the `&confirm=t` parameter. This can be verified by trying to download one of the models. Swapping to a library may be preferred for long-term support.

Separately, the installation with Docker would not run due to an error on `import cv2`. This appears to due to a change in `opencv-python` since `requirements.txt` was uploaded. This fixes that error by forcing all of the `opencv-python` dependencies to version `4.5.4.58` which was the current version as of Nov 12, 2021 when `requirements.txt` was originally committed. I do not know that this is the *correct* version, but it resulted in a working build for me. 